### PR TITLE
Missing updates from version 5.74, corrected warning/error for latest versions of Python 2.7 and added instructions about Ubuntu 16.04

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -4,6 +4,26 @@ for Windows and Mac are available at vpython.org. See HACKING.txt
 for details on how to do development work with the source code for
 Linux.
 
+*********************************************
+QUICK INFO for Ubuntu 16.04:
+
+sudo apt-get update
+sudo apt-get install autoconf libtool libgtkglextmm-x11-1.2-dev libglademm-2.4-dev python-dev python-pip python-numpy libboost-python-dev libboost-thread-dev libboost-signals-dev
+sudo pip install polygon2 ttfquery fonttools==3.44
+wget https://github.com/vpython/vpython.docs/archive/master.zip
+unzip -q master.zip
+mv -f vpython.docs-master docs
+sh ./autogen.sh
+./configure
+make
+sudo make install
+sudo rm -Rf /usr/local/lib/python2.7/dist-packages/visual
+sudo mv -f /usr/local/lib/python2.7/site-packages/visual /usr/local/lib/python2.7/dist-packages/
+sudo rm -Rf /usr/local/lib/python2.7/dist-packages/vis
+sudo mv -f /usr/local/lib/python2.7/site-packages/vis /usr/local/lib/python2.7/dist-packages/
+
+*********************************************
+
 Windows and Mac builds are now special to them; 
 see VCBuild/VCBuild.txt and MAC-OSX.txt.
 
@@ -20,7 +40,7 @@ I.  Prerequisites:
 	of the packages to ensure that the required header files are 
 	available.
 	
-	GNU g++ version 3.2.x or >= 3.3.1 (3.4.6 reccomended) (gcc.gnu.org).
+	GNU g++ version 3.2.x or >= 3.3.1 (3.4.6 recommended) (gcc.gnu.org).
 	An implementation of OpenGL.
 	The Boost C++ libraries version 1.31 and higher (1.33.1 reccomended)
 		(www.boost.org). Note that 1.31 is required if you are using Python 

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,8 +12,8 @@ EXTRA_DIST = include HACKING.txt INSTALL.txt \
 dist-hook:
 	rm -rf `find $(distdir)/include -name CVS` $(distdir)/include/config.h
 
-# Logic to install the "vpython" script
-bin_SCRIPTS = bin/vpython
+# Logic to install the "vpython" script (doesn't work properly)
+#bin_SCRIPTS = bin/vpython
 
 if BUILD_EXAMPLES
 SUBDIRS += examples

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 
 # Process this file with Autoconf to produce a configure script
 
-AC_INIT( [Visual Python], [5.71_release], [visualpython-users@lists.sourceforge.net])
-AM_INIT_AUTOMAKE( visual, 5.71_release)
+AC_INIT( [Visual Python], [5.74_release], [visualpython-users@lists.sourceforge.net])
+AM_INIT_AUTOMAKE( visual, 5.74_release)
 
 AC_CONFIG_SRCDIR(src/core/arrow.cpp)
 
@@ -87,7 +87,7 @@ fi
 AC_SUBST([PYTHONPATH], "$python_path")
 
 AC_CONFIG_FILES( Makefile src/Makefile site-packages/visual/Makefile site-packages/vis/Makefile 
-	docs/Makefile examples/Makefile bin/vpython)
+	docs/Makefile examples/Makefile)
 AM_CONFIG_HEADER( include/config.h)
 
 AC_OUTPUT()

--- a/site-packages/vis/__init__.py
+++ b/site-packages/vis/__init__.py
@@ -1,4 +1,4 @@
-version = ('5.72', 'release')
+version = ('5.74', 'release')
 
 from .cvisual import (vector, dot, mag, mag2, norm, cross, rotate,
                        comp, proj, diff_angle, rate, waitclose)

--- a/site-packages/vis/materials.py
+++ b/site-packages/vis/materials.py
@@ -67,7 +67,10 @@ class raw_texture(cvisual.texture):
     def __init__(self, **kwargs):
         cvisual.texture.__init__(self)
         for key, value in kwargs.items():
-            self.__setattr__(key, value)
+            if key=='data' and value is None:
+                raise RuntimeError, "Cannot nullify a texture by assigning its data to None"
+            else:
+                self.__setattr__(key, value)
 
 class shader_material(cvisual.material):
     def __init__(self, **kwargs):

--- a/src/linux-symbols.map
+++ b/src/linux-symbols.map
@@ -1,7 +1,6 @@
 CVISUAL_0_0 {
 	global:
 		initcvisual;
-		PyInit_cvisual;
 	local:
 		*;
 };

--- a/src/python/numeric_texture.cpp
+++ b/src/python/numeric_texture.cpp
@@ -255,10 +255,10 @@ void
 numeric_texture::set_data( boost::python::numeric::array data)
 {
 	namespace py = boost::python;
-	if (data == py::object() && texdata != py::object()) {
-		throw std::invalid_argument(
-			"Cannot nullify a texture by assigning its data to None");
-	}
+	//if (data == py::object() && texdata != py::object()) {
+	//	throw std::invalid_argument(
+	//		"Cannot nullify a texture by assigning its data to None");
+	//}
 
 	NPY_TYPES t = type(data);
 	if (t == NPY_CFLOAT || t == NPY_CDOUBLE || t == NPY_OBJECT || t == NPY_NOTYPE)


### PR DESCRIPTION
This repo was missing updates from **5.74** release available on http://sourceforge.net/projects/vpythonwx/files/5.74-release/visual-5.74_release.tar.bz2/download, so I propose to integrate them here. 

Also, on recent versions of **Python 2.7**, 
```python
import visual
```
may give a warning 
```python
/usr/local/lib/python2.7/dist-packages/vis/materials.py:70: FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.
  self.__setattr__(key, value)
```
which seem to become an error 
```python
/usr/local/lib/python2.7/dist-packages/vis/materials.py:70: ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
on more recent versions, so I propose to integrate a fix from the code of **vpython-wx**.

I added instructions in `INSTALL.txt` to be able to rebuild easily on **Ubuntu 16.04**. However, for **Ubuntu 18.04** compatibility, see #12.
